### PR TITLE
fix: add missing core imports

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,3 +1,4 @@
+import core from '@actions/core';
 import { execFileSync } from 'node:child_process';
 
 import { executeAction } from './src/index.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import core from '@actions/core';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 


### PR DESCRIPTION
I thought core was a global based on it being used as such before in `debug.js`