### PR TITLE
Fix build with custom typedoc.json

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: 'Build documentation using TypeDoc'
 inputs:
   entry:
     description: 'Entry point of your API'
-    required: true
+    required: false
     default: 'src/index.ts'
   treatWarningsAsErrors:
     description: 'Treat warnings as errors'


### PR DESCRIPTION
- **fix: make entry input optional**
  - It can be set inside a custom `typedoc.json` file.
- **fix: run typedoc from project's folder instead of action**
  - Makes resolution of typedoc.json and things it references easier.
  - Makes conditional installation of TS unnecessary.